### PR TITLE
Register Rétroliens to the Entrepôt

### DIFF
--- a/repositories/plugins/retroliens.json
+++ b/repositories/plugins/retroliens.json
@@ -1,0 +1,27 @@
+{
+  "name": "Rétroliens",
+  "author": "imath",
+  "slug": "retroliens",
+  "dependencies": [
+      {
+        "unregister_block_style" : "WordPress 5.3"
+      }
+  ],
+  "icon": "https://raw.githubusercontent.com/imath/retroliens/master/icon.png",
+  "tags": [
+    "TrackBack",
+    "Block",
+    "Gutenberg"
+  ],
+  "country": "fr_FR",
+  "releases": "https://github.com/imath/retroliens/releases",
+  "issues": "https://github.com/imath/retroliens/issues",
+  "description": {
+      "en_US" : "Adds a new sidebar to the WordPress Blocks Editor to manage trackbacks.",
+      "fr_FR" : "Ajoute une barre latérale à l'éditeur de blocs pour envoyer des rétroliens."
+  },
+  "README": "https://raw.githubusercontent.com/imath/retroliens/master/README.md",
+  "urls": {
+    "donate": "https://paypal.me/imath"
+  }
+}


### PR DESCRIPTION
## What your pull request is about ?

<!-- Please choose only one of the option below. -->

- [x] it's about registering`*` a plugin repository.
- [ ] it's about registering`*` a theme repository.
- [ ] it's about registering`*` a block repository.
- [ ] it's about the Entrepôt plugin's code improvement.

`*` Read the Plugin/theme/block author's [documentation](https://github.com/imath/entrepot/wiki) for more information. By registering a plugin, a theme or a block, I'm agreeing with the [code of conduct](https://github.com/imath/entrepot/blob/master/CODE_OF_CONDUCT.md).

<!-- If you wish to register your repository into the Entrepôt : -->

<!-- 1. Make sure to publish GitHub releases including a Zip Archive of your repository into its download section (using your plugin/theme/block's slug to name this Zip Archive). -->
<!-- 2. Make sure to always be up to date with latest WordPress release. -->
<!-- 3. Make sure your plugin/theme/block's slug is unique : there cannot be duplicates which means you cannot register to the Entrepôt if your plugin, theme or block is hosted on [WordPress.org](https://wordpress.org/plugins/). -->
<!-- 4. Your plugin, theme or block must be **GPL** compatible, **free to use** with **no ads nowhere into its source code**. -->
